### PR TITLE
Webpack: Abstract sourcemaps for multiple targets

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -1,0 +1,7 @@
+"use strict";
+
+// Meta configuration for webpack, etc.
+module.exports = {
+  FILE_NAME: "boilerplate-component",
+  LIB_NAME: "BoilerplateComponent"
+};

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -5,9 +5,9 @@ var config = require("./webpack.config");
 
 // **WARNING**: Mutates base configuration.
 // We do this because lodash isn't available in `production` mode.
-config.output.filename = "boilerplate-component.js";
+config.output.filename = config._CONFIG.FILE_NAME + ".js";
 config.plugins = [
-  new webpack.SourceMapDevToolPlugin("boilerplate-component.js.map")
+  new webpack.SourceMapDevToolPlugin("[file].map")
 ];
 
 // Export mutated base.

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -2,10 +2,11 @@
 
 var webpack = require("webpack");
 var config = require("./webpack.config");
+var meta = require("./meta");
 
 // **WARNING**: Mutates base configuration.
 // We do this because lodash isn't available in `production` mode.
-config.output.filename = config._CONFIG.FILE_NAME + ".js";
+config.output.filename = meta.FILE_NAME + ".js";
 config.plugins = [
   new webpack.SourceMapDevToolPlugin("[file].map")
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,14 @@
 var webpack = require("webpack");
 var path = require("path");
 
+// Set up shared config to reuse in other configurations.
+var _CONFIG = {
+  FILE_NAME: "boilerplate-component",
+  LIB_NAME: "BoilerplateComponent"
+};
+
 module.exports = {
+  _CONFIG: _CONFIG, // Proxy configuration for later imports.
   cache: true,
   entry: path.join(__dirname, "src/index.js"),
   externals: [
@@ -18,8 +25,8 @@ module.exports = {
   ],
   output: {
     path: path.join(__dirname, "dist"),
-    filename: "boilerplate-component.min.js",
-    library: "BoilerplateComponent",
+    filename: _CONFIG.FILE_NAME + ".min.js",
+    library: _CONFIG.LIB_NAME,
     libraryTarget: "umd"
   },
   resolve: {
@@ -48,11 +55,10 @@ module.exports = {
       }
     }),
     new webpack.DefinePlugin({
-      "process.env": {
-        // Signal production mode for React JS and other libs.
-        NODE_ENV: JSON.stringify("production")
-      }
+      // Signal production, so that webpack removes non-production code that
+      // is in condtionals like: `if (process.env.NODE_ENV === "production")`
+      "process.env.NODE_ENV": JSON.stringify("production")
     }),
-    new webpack.SourceMapDevToolPlugin("boilerplate-component.min.js.map")
+    new webpack.SourceMapDevToolPlugin("[file].map")
   ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,15 +2,9 @@
 
 var webpack = require("webpack");
 var path = require("path");
-
-// Set up shared config to reuse in other configurations.
-var _CONFIG = {
-  FILE_NAME: "boilerplate-component",
-  LIB_NAME: "BoilerplateComponent"
-};
+var meta = require("./meta");
 
 module.exports = {
-  _CONFIG: _CONFIG, // Proxy configuration for later imports.
   cache: true,
   entry: path.join(__dirname, "src/index.js"),
   externals: [
@@ -25,8 +19,8 @@ module.exports = {
   ],
   output: {
     path: path.join(__dirname, "dist"),
-    filename: _CONFIG.FILE_NAME + ".min.js",
-    library: _CONFIG.LIB_NAME,
+    filename: meta.FILE_NAME + ".min.js",
+    library: meta.LIB_NAME,
     libraryTarget: "umd"
   },
   resolve: {


### PR DESCRIPTION
This PR
- Moves some naming stuff to an internal `_CONFIG` in webpack.
- Switch source map file names to `"[file].map"` which effectively handles multiple targets (like a `bundle.js` and `bundle.css` -- prior to this change we'd get _one_ source map only for the _last_ file generated).

/cc @boygirl @kenwheeler @divmain 
