### PR TITLE
Chore: Enforce dash-cased filenames.

### DIFF
--- a/.eslintrc-base
+++ b/.eslintrc-base
@@ -1,0 +1,5 @@
+---
+"plugins":
+  - "filenames"
+"rules":
+  "filenames/filenames": [2, "^[a-z\\-\\.]+$"] # dash-cased filenames.

--- a/.eslintrc-node
+++ b/.eslintrc-node
@@ -1,3 +1,4 @@
 ---
 "extends":
   - "defaults/configurations/walmart/es5-node"
+  - ".eslintrc-base"

--- a/.eslintrc-react
+++ b/.eslintrc-react
@@ -1,3 +1,4 @@
 ---
 "extends":
   - "defaults/configurations/walmart/es6-react"
+  - ".eslintrc-base"

--- a/.eslintrc-react-test
+++ b/.eslintrc-react-test
@@ -2,3 +2,4 @@
 "extends":
   - "defaults/configurations/walmart/es6-react"
   - "defaults/environments/test"
+  - ".eslintrc-base"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "chai": "^3.2.0",
     "eslint": "^0.24.1",
     "eslint-config-defaults": "^3.0.3",
+    "eslint-plugin-filenames": "^0.1.1",
     "eslint-plugin-react": "^2.6.4",
     "karma": "^0.12.37",
     "karma-chrome-launcher": "^0.2.0",


### PR DESCRIPTION
Add eslint plugin and enforcement of dash-cased filenames.

/cc @boygirl @baer @divmain @kenwheeler 
