### PR TITLE
use meta file name whenever possible for generator ease

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -1,12 +1,12 @@
 /*global document:false*/
 import React from "react";
-import {BoilerplateComponent} from "../src/index";
+import {Component} from "../src/index";
 
 class App extends React.Component {
   render() {
     return (
       <div className="demo">
-        < BoilerplateComponent />
+        < Component />
       </div>
     );
   }

--- a/demo/webpack.config.dev.js
+++ b/demo/webpack.config.dev.js
@@ -2,6 +2,8 @@
 "use strict";
 
 var webpack = require("webpack");
+var path = require("path");
+var meta = require("../meta")
 
 module.exports = {
 
@@ -26,7 +28,10 @@ module.exports = {
     reasons: true
   },
   resolve: {
-    extensions: ["", ".js", ".jsx"]
+    extensions: ["", ".js", ".jsx"],
+    alias: {
+      component: "./components/" + meta.FILE_NAME
+    }
   },
   module: {
     loaders: [

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 module.exports = {
-  BoilerplateComponent: require("./components/boilerplate-component")
+  // "component" is an alias src/components/[FILE_NAME].jsx
+  Component: require("component")
 };

--- a/test/client/spec/components/boilerplate-component.spec.jsx
+++ b/test/client/spec/components/boilerplate-component.spec.jsx
@@ -2,7 +2,8 @@
  * Client tests
  */
 import React from "react/addons";
-import Component from "src/components/boilerplate-component";
+// component is an alias src/components/[FILE_NAME].jsx
+import Component from "component";
 
 // Use `TestUtils` to inject into DOM, simulate events, etc.
 // See: https://facebook.github.io/react/docs/test-utils.html

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,10 @@ module.exports = {
     libraryTarget: "umd"
   },
   resolve: {
-    extensions: ["", ".js", ".jsx"]
+    extensions: ["", ".js", ".jsx"],
+    alias: {
+      component: "./components/" + meta.FILE_NAME
+    }
   },
   module: {
     loaders: [

--- a/webpack.config.test.js
+++ b/webpack.config.test.js
@@ -5,6 +5,7 @@
 var path = require("path");
 var _ = require("lodash");
 var prodCfg = require("./webpack.config");
+var meta = require("./meta");
 
 module.exports = {
   cache: true,
@@ -18,7 +19,8 @@ module.exports = {
   resolve: _.merge({}, prodCfg.resolve, {
     alias: {
       // Allow root import of `src/FOO` from ROOT/src.
-      src: path.join(__dirname, "src")
+      src: path.join(__dirname, "src"),
+      component: path.join(__dirname, "src/components/", meta.FILE_NAME)
     }
   }),
   module: prodCfg.module,


### PR DESCRIPTION
cc/ @ryan-roemer 

this sets up aliases for `src/component/[FILE_NAME]` so that there are fewer names to change on a generated project.
