### PR TITLE
Boilerplate replace script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+max_line_length = 100
 
 [*.md]
 trim_trailing_whitespace = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,11 @@ Run `npm run demo` to run a webpack dev server with component examples.
 
 ## Generator Specific
 
-All boilerplate components should be named `boilerplate-component` or `BoilerplateComponent` as appropriate.
+All boilerplate components should be named `boilerplate-component` or 
+`BoilerplateComponent` as appropriate.
 
-`src/components/boilerplate-component.jsx` SHOULD NOT be moved or renamed
+`src/components/boilerplate-component.jsx` and 
+`test/client/spec/components/boilerplate-component.spec.jsx` SHOULD NOT be moved or renamed
 
 ## Checks, Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,14 @@ Thanks for helping out!
 
 Run `npm run demo` to run a webpack dev server with component examples.
 
+## Generator Specific
+
+All boilerplate components should be named `boilerplate-component` or `BoilerplateComponent` as appropriate.
+
+`src/components/boilerplate-component.jsx` SHOULD NOT be moved or renamed
+
+The dev dependency `replace` is required by the generator.
+
 ## Checks, Tests
 
 Run `npm run check` before committing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,6 @@ All boilerplate components should be named `boilerplate-component` or `Boilerpla
 
 `src/components/boilerplate-component.jsx` SHOULD NOT be moved or renamed
 
-The dev dependency `replace` is required by the generator.
-
 ## Checks, Tests
 
 Run `npm run check` before committing.

--- a/README.md
+++ b/README.md
@@ -4,26 +4,25 @@
 React Component Boilerplate
 ===========================
 
-Formidable Labs flavored React component boilerplate. This is a set of opinions
-on how to start a React component.
+Formidable Labs flavored React component boilerplate. This is a set of opinions on how to start a React component.
 
 ## Make it yours!
 Create a new project based on this repo by running our handy yeoman generator!
+
 ```
 npm install -g yeoman
 npm install -g generator-formidable-react-component
 yo formidable-react-component
 ```
+
 the generator will clone down this repo at `master`, `npm install`, and rename generic boilerplate to match the project name you specify. 
 
 ## The Generator
 
-We expect these opinions to change *often*.  We've written a yeoman generator to
-pull down the freshest copy of this repo whenever you use it.  It just copies
-this repo so you don't have to. Check it out
-[here](https://github.com/FormidableLabs/generator-formidable-react-component)
+We expect these opinions to change *often*.  We've written a yeoman generator to pull down the freshest copy of this repo whenever you use it.  It just copies this repo so you don't have to. Check it out [here](https://github.com/FormidableLabs/generator-formidable-react-component)
 
-The generator replaces `boilerplate-component` and `BoilerplateComponent` across this repo, and renames `src/components/boilerplate-component.jsx`
+The generator replaces `boilerplate-component` and `BoilerplateComponent` across this repo, and renames `src/components/boilerplate-component.jsx` and 
+`test/client/spec/components/boilerplate-component.spec.jsx`
 
 ## Build
 
@@ -50,8 +49,7 @@ Note that `dist/` files are only updated and committed on **tagged releases**.
 
 ## Development
 
-All development tasks consist of watching the demo bundle, the test bundle
-and launching a browser pointed to the demo page.
+All development tasks consist of watching the demo bundle, the test bundle and launching a browser pointed to the demo page.
 
 Run the `demo` application in a browser window with hot reload:
 (More CPU usage, but faster, more specific updates)
@@ -97,13 +95,11 @@ $ npm run lint
 $ npm run test-dev
 ```
 
-Note that the tests here are not instrumented for code coverage and are thus
-more development / debugging friendly.
+Note that the tests here are not instrumented for code coverage and are thus more development / debugging friendly.
 
 ### Continuous Integration
 
-CI doesn't have source / test file watchers, so has to _build_ the test files
-via the commands:
+CI doesn't have source / test file watchers, so has to _build_ the test files via the commands:
 
 ```
 $ npm run check     # PhantomJS only
@@ -143,9 +139,7 @@ coverage/
 
 ## Releases
 
-Built files in `dist/` should **not** be committeed during development or PRs.
-Instead we _only_ build and commit them for published, tagged releases. So
-the basic workflow is:
+Built files in `dist/` should **not** be committeed during development or PRs. Instead we _only_ build and commit them for published, tagged releases. So the basic workflow is:
 
 ```
 # Update version

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ Formidable Labs flavored React component boilerplate. This is a set of opinions
 on how to start a React component.
 
 ## Make it yours!
-
-The top level component in this boilerplate repo is called
-`BoilerplateComponent`. You probably want to change that. Remember to update
-`src/index.js`, `webpack.config.js`, and `webpack.config.dev.js`to reflect your
-naming changes!
+Create a new project based on this repo by running our handy yeoman generator!
+```
+npm install -g yeoman
+npm install -g generator-formidable-react-component
+yo formidable-react-component
+```
+the generator will clone down this repo at `master`, `npm install`, and rename generic boilerplate to match the project name you specify. 
 
 ## The Generator
 
@@ -21,6 +23,7 @@ pull down the freshest copy of this repo whenever you use it.  It just copies
 this repo so you don't have to. Check it out
 [here](https://github.com/FormidableLabs/generator-formidable-react-component)
 
+The generator replaces `boilerplate-component` and `BoilerplateComponent` across this repo, and renames `src/components/boilerplate-component.jsx`
 
 ## Build
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "phantomjs": "^1.9.17",
     "react": "0.13.x",
     "react-hot-loader": "^1.2.8",
-    "replace": "0.3.0",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0",
     "webpack-dev-server": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "phantomjs": "^1.9.17",
     "react": "0.13.x",
     "react-hot-loader": "^1.2.8",
+    "replace": "0.3.0",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0",
     "webpack-dev-server": "^1.10.0"


### PR DESCRIPTION
cc/ @ryan-roemer 

This PR adds the dev dependency `replace` which is used by the generator, and updates the docs.  I'm not thrilled about having to add a dependency here for the generator to use, but yeoman is profoundly weird.  the other option is straight terminal commands from the generator.  The code there gets quite ugly.  Both implementations only work on unix systems. 
