### PR TITLE
update and organize docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+max_line_length = 100
 
 [*.md]
 trim_trailing_whitespace = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,11 @@ Run `npm run check` before committing.
 
 Please do not commit changes to files in `dist`.
 These files are only committed when we tag releases.
+
+## Generator Compatibility 
+
+All boilerplate components should be named `boilerplate-component` or 
+`BoilerplateComponent` as appropriate.
+
+`src/components/boilerplate-component.jsx` and 
+`test/client/spec/components/boilerplate-component.spec.jsx` SHOULD NOT be moved or renamed

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,139 @@
+Development
+===========
+
+## Build
+
+Build for production use (NPM, bower, etc) and create `dist` UMD bundles
+(min'ed, non-min'ed)
+
+```
+$ npm run build
+```
+
+Note that `dist/` files are only updated and committed on **tagged releases**.
+
+
+## Development
+
+All development tasks consist of watching the demo bundle, the test bundle
+and launching a browser pointed to the demo page.
+
+Run the `demo` application with watched rebuilds:
+
+```
+$ npm run dev       # dev test/app server (OR)
+$ npm run open-dev  # dev servers _and a browser window opens!_
+```
+
+From there you can see:
+
+* Demo app: [127.0.0.1:3000](http://127.0.0.1:3000/)
+* Client tests: [127.0.0.1:3001/test/client/test.html](http://127.0.0.1:3001/test/client/test.html)
+
+## Quality
+
+### In Development
+
+During development, you are expected to be running either:
+
+```
+$ npm run dev
+```
+
+to build the lib and test files. With these running, you can run the faster
+
+```
+$ npm run check-dev
+```
+
+Command. It is comprised of:
+
+```
+$ npm run lint
+$ npm run test-dev
+```
+
+Note that the tests here are not instrumented for code coverage and are thus
+more development / debugging friendly.
+
+### Continuous Integration
+
+CI doesn't have source / test file watchers, so has to _build_ the test files
+via the commands:
+
+```
+$ npm run check     # PhantomJS only
+$ npm run check-cov # (OR) PhantomJS w/ coverage
+$ npm run check-ci  # (OR) PhantomJS,Firefox + coverage - available on Travis.
+```
+
+Which is currently comprised of:
+
+```
+$ npm run lint      # AND ...
+
+$ npm run test      # PhantomJS only
+$ npm run test-cov  # (OR) PhantomJS w/ coverage
+$ npm run test-ci   # (OR) PhantomJS,Firefox + coverage
+```
+
+Note that `(test|check)-(cov|ci)` run code coverage and thus the
+test code may be harder to debug because it is instrumented.
+
+### Client Tests
+
+The client tests rely on webpack dev server to create and serve the bundle
+of the app/test code at: http://127.0.0.1:3001/assets/main.js which is done
+with the task `npm run server-test` (part of `npm dev`).
+
+#### Code Coverage
+
+Code coverage reports are outputted to:
+
+```
+coverage/
+  client/
+    BROWSER_STRING/
+      lcov-report/index.html  # Viewable web report.
+```
+
+## Releases
+
+Built files in `dist/` should **not** be committeed during development or PRs.
+Instead we _only_ build and commit them for published, tagged releases. So
+the basic workflow is:
+
+* [`npm version`](https://docs.npmjs.com/cli/version): Runs verification,
+  builds `dist/` and `lib/` via `scripts` commands.
+    * Our scripts also run the applicable `git` commands, so be very careful
+      when running out `version` commands.
+* [`npm publish`](https://docs.npmjs.com/cli/publish): Uploads to NPM.
+    * **NOTE**: We don't _build_ in `prepublish` because of the
+      [`npm install` runs `npm prepublish` bug](https://github.com/npm/npm/issues/3059)
+
+
+**Note - NPM**: To correctly run `preversion`, etc. scripts, please make sure
+you have a very modern `npm` binary:
+
+```
+$ npm install -g npm
+```
+
+In code:
+
+```
+# Update version (_probably_ `patch`), rebuild `dist/` and `lib/`.
+$ npm version major|minor|patch -m "Version %s - INSERT_REASONS"
+# ... the project is now patched and committed to git (but unpushed).
+
+# Check that everything looks good in last commit and push.
+$ git diff HEAD^ HEAD
+$ git push && git push --tags
+# ... the project is now pushed to GitHub and available to `bower`.
+
+# And finally publish to `npm`!
+$ npm publish
+```
+
+Side note: `npm publish` runs `npm prepublish` under the hood, which does the
+build.

--- a/README.md
+++ b/README.md
@@ -7,177 +7,23 @@ React Component Boilerplate
 Formidable Labs flavored React component boilerplate. This is a set of opinions
 on how to start a React component.
 
-## Make it yours!
-
-The top level component in this boilerplate repo is called
-`BoilerplateComponent`. You probably want to change that. Remember to update
-`src/index.js`, `webpack.config.js`, and `webpack.config.dev.js`to reflect your
-naming changes!
-
 ## The Generator
 
-We expect these opinions to change *often*.  We've written a yeoman generator to
-pull down the freshest copy of this repo whenever you use it.  It just copies
-this repo so you don't have to. Check it out
-[here](https://github.com/FormidableLabs/generator-formidable-react-component)
+We expect these opinions to change *often*.  We've written a yeoman generator to pull down the freshest copy of this repo whenever you use it.  It just copies this repo so you don't have to. Check it out [here](https://github.com/FormidableLabs/generator-formidable-react-component)
 
-
-## Build
-
-Build for production use (NPM, bower, etc).
+To create a new project based on this boilerplate:
 
 ```
-$ npm run build
+npm install -g yo
+npm install -g generator-formidable-react-component
+yo formidable-react-component
 ```
 
-Which is composed of commands to create `dist` UMD bundles (min'ed, non-min'ed)
-
-```
-$ npm run build-dist
-```
-
-and the ES5 `lib`:
-
-```
-$ npm run build-lib
-```
-
-Note that `dist/` files are only updated and committed on **tagged releases**.
-
+The generator replaces "boilerplate-component" and "BoilerplateComponent" across this repo with names specific to your new project. `src/components/boilerplate-component.jsx` and `test/client/spec/components/boilerplate-component.spec.jsx` are also renamed, and a fresh `README.md` is created.
 
 ## Development
 
-All development tasks consist of watching the demo bundle, the test bundle
-and launching a browser pointed to the demo page.
-
-Run the `demo` application in a browser window with hot reload:
-(More CPU usage, but faster, more specific updates)
-
-```
-$ npm run hot       # hot test/app server (OR)
-$ npm run open-hot  # hot servers _and a browser window opens!_
-```
-
-Run the `demo` application with watched rebuilds, but not hot reload:
-
-```
-$ npm run dev       # dev test/app server (OR)
-$ npm run open-dev  # dev servers _and a browser window opens!_
-```
-
-From there you can see:
-
-* Demo app: [127.0.0.1:3000](http://127.0.0.1:3000/)
-* Client tests: [127.0.0.1:3001/test/client/test.html](http://127.0.0.1:3001/test/client/test.html)
-
-## Quality
-
-### In Development
-
-During development, you are expected to be running either:
-
-```
-$ npm run dev
-$ npm run hot
-```
-
-to build the src and test files. With these running, you can run the faster
-
-```
-$ npm run check-dev
-```
-
-Command. It is comprised of:
-
-```
-$ npm run lint
-$ npm run test-dev
-```
-
-Note that the tests here are not instrumented for code coverage and are thus
-more development / debugging friendly.
-
-### Continuous Integration
-
-CI doesn't have source / test file watchers, so has to _build_ the test files
-via the commands:
-
-```
-$ npm run check     # PhantomJS only
-$ npm run check-cov # (OR) PhantomJS w/ coverage
-$ npm run check-ci  # (OR) PhantomJS,Firefox + coverage - available on Travis.
-```
-
-Which is currently comprised of:
-
-```
-$ npm run lint      # AND ...
-
-$ npm run test      # PhantomJS only
-$ npm run test-cov  # (OR) PhantomJS w/ coverage
-$ npm run test-ci   # (OR) PhantomJS,Firefox + coverage
-```
-
-Note that `(test|check)-(cov|ci)` run code coverage and thus the
-test code may be harder to debug because it is instrumented.
-
-### Client Tests
-
-The client tests rely on webpack dev server to create and serve the bundle
-of the app/test code at: http://127.0.0.1:3001/assets/main.js which is done
-with the task `npm run server-test` (part of `npm dev` and `npm hot`).
-
-#### Code Coverage
-
-Code coverage reports are outputted to:
-
-```
-coverage/
-  client/
-    BROWSER_STRING/
-      lcov-report/index.html  # Viewable web report.
-```
-
-## Releases
-
-Built files in `dist/` should **not** be committeed during development or PRs.
-Instead we _only_ build and commit them for published, tagged releases. So
-the basic workflow is:
-
-* [`npm version`](https://docs.npmjs.com/cli/version): Runs verification,
-  builds `dist/` and `lib/` via `scripts` commands.
-    * Our scripts also run the applicable `git` commands, so be very careful
-      when running out `version` commands.
-* [`npm publish`](https://docs.npmjs.com/cli/publish): Uploads to NPM.
-    * **NOTE**: We don't _build_ in `prepublish` because of the
-      [`npm install` runs `npm prepublish` bug](https://github.com/npm/npm/issues/3059)
-
-
-**Note - NPM**: To correctly run `preversion`, etc. scripts, please make sure
-you have a very modern `npm` binary:
-
-```
-$ npm install -g npm
-```
-
-In code:
-
-```
-# Update version (_probably_ `patch`), rebuild `dist/` and `lib/`.
-$ npm version major|minor|patch -m "Version %s - INSERT_REASONS"
-# ... the project is now patched and committed to git (but unpushed).
-
-# Check that everything looks good in last commit and push.
-$ git diff HEAD^ HEAD
-$ git push && git push --tags
-# ... the project is now pushed to GitHub and available to `bower`.
-
-# And finally publish to `npm`!
-$ npm publish
-```
-
-Side note: `npm publish` runs `npm prepublish` under the hood, which does the
-build.
+Please see [DEVELOPMENT](DEVELOPMENT.md)
 
 ## Contributing
 


### PR DESCRIPTION
cc/ @ryan-roemer I liked how you split out the development docs into their own file in abstract-log, and I've copied that here, and added some notes about generator compatibility.  I will update the readme template in the generator to reflect this change.
