### PR TITLE
Chore: Changes eval-source-map to source-map

### DIFF
--- a/demo/webpack.config.dev.js
+++ b/demo/webpack.config.dev.js
@@ -17,7 +17,7 @@ module.exports = {
   },
 
   cache: true,
-  devtool: "eval-source-map",
+  devtool: "source-map",
   entry: {
     app: ["./demo/app.jsx"]
   },


### PR DESCRIPTION
cc @ryan-roemer ran `npm run check` and all `lint` and `test` tasks passed.
